### PR TITLE
Add simplified CLI tools for running YAML simulations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+# Gale-Shapley Simulator Makefile
+
+.PHONY: help build run test clean run-empty run-asymmetric run-stable
+
+help:
+	@echo "Gale-Shapley Simulator - Available commands:"
+	@echo ""
+	@echo "  make build        - Build the executable JAR"
+	@echo "  make run          - Run with default config"
+	@echo "  make run FILE=... - Run with custom YAML file"
+	@echo "  make test         - Run all tests"
+	@echo "  make clean        - Clean build artifacts"
+	@echo ""
+	@echo "Quick test scenarios:"
+	@echo "  make run-empty    - Run empty set preference scenario"
+	@echo "  make run-asymmetric - Run asymmetric matching scenario"  
+	@echo "  make run-stable   - Run stable matching scenario"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make run FILE=my-config.yaml"
+	@echo "  make run FILE=src/test/resources/empty-set-config.yaml"
+
+build:
+	@echo "Building Gale-Shapley simulator..."
+	@mvn package -q
+
+run:
+	@mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="$(FILE)" -q
+
+run-empty:
+	@echo "Running empty set preference scenario..."
+	@mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="src/test/resources/empty-set-config.yaml" -q
+
+run-asymmetric:
+	@echo "Running asymmetric matching scenario..."
+	@mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="src/test/resources/asymmetric-matching-config.yaml" -q
+
+run-stable:
+	@echo "Running stable matching scenario..."
+	@mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="src/test/resources/stable-matching-config.yaml" -q
+
+test:
+	@mvn test
+
+clean:
+	@mvn clean
+	@echo "Clean complete."

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A Java-based simulator for the Gale-Shapley stable matching algorithm with suppo
 
 - **Object-Oriented Design**: Clean separation of concerns with models for Proposers, Proposees, Preferences, and Matchings
 - **YAML Configuration**: Easy configuration of simulation scenarios using YAML files
+- **Empty Set Preferences**: Support for agents who prefer being single over certain matches using `∅` symbol
 - **Observer Pattern**: Monitor algorithm execution with built-in console and statistics observers
+- **Simplified CLI**: Easy-to-use shell scripts and Makefile for running simulations
 - **Test-Driven Development**: Comprehensive unit tests using JUnit 5
 - **Extensible Architecture**: Easy to add constraints and edge cases in future iterations
 
@@ -60,7 +62,45 @@ mvn test
 
 ## Running the Simulator
 
-### Basic Usage
+### Quick Start (Simplified CLI)
+
+For the easiest way to run simulations, use the provided convenience scripts:
+
+#### Shell Script (recommended)
+```bash
+# Run with default configuration
+./run-simulation
+
+# Run with custom YAML file
+./run-simulation my-config.yaml
+
+# Run with test configurations
+./run-simulation src/test/resources/empty-set-config.yaml
+./run-simulation src/test/resources/asymmetric-matching-config.yaml
+
+# Get help
+./run-simulation --help
+```
+
+#### Makefile Commands
+```bash
+# See all available commands
+make help
+
+# Run different scenarios
+make run-empty        # Empty set preferences scenario
+make run-asymmetric   # Asymmetric matching scenario  
+make run-stable       # Stable matching scenario
+
+# Run with custom file
+make run FILE=my-config.yaml
+
+# Build and test
+make build
+make test
+```
+
+### Advanced Usage (Maven)
 
 #### Using the example configuration:
 
@@ -72,6 +112,16 @@ mvn exec:java -Dexec.mainClass="com.galeshapley.Main"
 
 ```bash
 mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="path/to/your/config.yaml"
+```
+
+#### Using the executable JAR:
+
+```bash
+# Build the JAR
+mvn package
+
+# Run with JAR (requires proper Java runtime configuration)
+java -jar target/gale-shapley.jar path/to/your/config.yaml
 ```
 
 ### CLI Output and Capturing Results

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <main.class>com.galeshapley.Main</main.class>
         <junit.version>5.10.0</junit.version>
         <mockito.version>5.5.0</mockito.version>
         <assertj.version>3.24.2</assertj.version>
@@ -93,6 +94,40 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+            </plugin>
+            
+            <!-- Maven Shade Plugin for creating fat JAR -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${main.class}</mainClass>
+                                </transformer>
+                            </transformers>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <finalName>gale-shapley</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- Exec Maven Plugin for easy CLI execution -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <mainClass>${main.class}</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/run-simulation
+++ b/run-simulation
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Gale-Shapley Simulator - Easy CLI Runner
+# Usage: ./run-simulation [config.yaml]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_usage() {
+    echo -e "${BLUE}Gale-Shapley Simulator${NC}"
+    echo "Usage: $0 [config.yaml]"
+    echo ""
+    echo "Examples:"
+    echo "  $0                                    # Run with default config"
+    echo "  $0 my-config.yaml                    # Run with custom config"
+    echo "  $0 src/test/resources/empty-set-config.yaml"
+    echo ""
+    echo "Available test configs:"
+    echo "  - src/test/resources/stable-matching-config.yaml"
+    echo "  - src/test/resources/asymmetric-matching-config.yaml"
+    echo "  - src/test/resources/empty-set-config.yaml"
+    echo "  - src/test/resources/consistent-results-config.yaml"
+}
+
+# Check if help requested
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+# Determine config file
+CONFIG_FILE="${1:-src/main/resources/example-config.yaml}"
+
+# Check if config file exists
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo -e "${RED}Error: Configuration file '$CONFIG_FILE' not found!${NC}" >&2
+    echo ""
+    print_usage
+    exit 1
+fi
+
+# Run the simulation using Maven (more reliable than JAR across different Java setups)
+echo -e "${BLUE}Running Gale-Shapley simulation with: $CONFIG_FILE${NC}"
+echo ""
+mvn exec:java -Dexec.mainClass="com.galeshapley.Main" -Dexec.args="\"$CONFIG_FILE\"" -q


### PR DESCRIPTION
## Summary
Adds multiple convenient ways to run YAML simulations, making the CLI much more user-friendly.

## New CLI Options

### 🚀 Shell Script (Recommended)
```bash
# Super simple usage
./run-simulation                                    # Default config
./run-simulation my-config.yaml                     # Custom YAML
./run-simulation src/test/resources/empty-set-config.yaml
```

### 🔧 Makefile Commands
```bash
make help             # See all commands
make run-empty        # Run empty set scenario
make run-stable       # Run stable matching scenario  
make run FILE=my.yaml # Run custom file
```

### 📦 Executable JAR
```bash
mvn package          # Creates target/gale-shapley.jar
java -jar target/gale-shapley.jar config.yaml
```

## Key Improvements
- **Maven Shade Plugin**: Creates fat JAR with all dependencies included
- **Smart Shell Script**: Handles file validation, colored output, help text
- **Makefile Shortcuts**: Quick access to test scenarios and custom configs
- **Updated README**: Comprehensive documentation for all CLI methods

## Usage Examples
```bash
# Quick test of different scenarios
./run-simulation src/test/resources/empty-set-config.yaml
make run-asymmetric
make run FILE=src/test/resources/stable-matching-config.yaml

# The shell script provides helpful error messages and usage info
./run-simulation --help
./run-simulation nonexistent.yaml  # Shows available test configs
```

🤖 Generated with [Claude Code](https://claude.ai/code)