### PR TITLE
Fix empty set preference handling

### DIFF
--- a/src/main/java/com/galeshapley/Main.java
+++ b/src/main/java/com/galeshapley/Main.java
@@ -27,7 +27,8 @@ public class Main {
             
             GaleShapleyAlgorithm algorithm = new GaleShapleyAlgorithm(
                 config.getProposerPreferences(),
-                config.getProposeePreferences()
+                config.getProposeePreferences(),
+                config.getEmptySetPreferences()
             );
             
             ConsoleObserver consoleObserver = new ConsoleObserver(true);

--- a/src/main/java/com/galeshapley/model/EmptySet.java
+++ b/src/main/java/com/galeshapley/model/EmptySet.java
@@ -1,0 +1,32 @@
+package com.galeshapley.model;
+
+/**
+ * Represents the empty set (∅) as a special Proposee.
+ * When a Proposer is matched with EmptySet, they prefer being single.
+ */
+public class EmptySet extends Proposee {
+    private static final EmptySet INSTANCE = new EmptySet();
+    
+    private EmptySet() {
+        super("∅", "EmptySet");
+    }
+    
+    public static EmptySet getInstance() {
+        return INSTANCE;
+    }
+    
+    @Override
+    public String toString() {
+        return "∅";
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof EmptySet;
+    }
+    
+    @Override
+    public int hashCode() {
+        return "EmptySet".hashCode();
+    }
+}

--- a/src/main/java/com/galeshapley/model/Matching.java
+++ b/src/main/java/com/galeshapley/model/Matching.java
@@ -95,9 +95,14 @@ public class Matching {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("Matching{\n");
-        proposerToProposee.forEach((proposer, proposee) -> 
-            sb.append("  ").append(proposer.getName()).append(" <-> ")
-              .append(proposee.getName()).append("\n"));
+        proposerToProposee.forEach((proposer, proposee) -> {
+            sb.append("  ").append(proposer.getName());
+            if (proposee instanceof EmptySet) {
+                sb.append(" -> single\n");
+            } else {
+                sb.append(" <-> ").append(proposee.getName()).append("\n");
+            }
+        });
         if (!unmatchedProposers.isEmpty()) {
             sb.append("  Unmatched Proposers: ");
             unmatchedProposers.forEach(p -> sb.append(p.getName()).append(" "));

--- a/src/main/java/com/galeshapley/observer/ConsoleObserver.java
+++ b/src/main/java/com/galeshapley/observer/ConsoleObserver.java
@@ -33,13 +33,21 @@ public class ConsoleObserver implements AlgorithmObserver {
     @Override
     public void onProposal(Proposer proposer, Proposee proposee) {
         if (verbose) {
-            System.out.println("  " + proposer.getName() + " proposes to " + proposee.getName());
+            if (proposee instanceof EmptySet) {
+                System.out.println("  " + proposer.getName() + " chooses to remain single");
+            } else {
+                System.out.println("  " + proposer.getName() + " proposes to " + proposee.getName());
+            }
         }
     }
     
     @Override
     public void onAcceptance(Proposer proposer, Proposee proposee) {
-        System.out.println("  ✓ " + proposee.getName() + " accepts " + proposer.getName());
+        if (proposee instanceof EmptySet) {
+            System.out.println("  ✓ " + proposer.getName() + " will remain single");
+        } else {
+            System.out.println("  ✓ " + proposee.getName() + " accepts " + proposer.getName());
+        }
     }
     
     @Override
@@ -62,9 +70,13 @@ public class ConsoleObserver implements AlgorithmObserver {
         System.out.println("\n=== Algorithm Complete ===");
         System.out.println("Total iterations: " + totalIterations);
         System.out.println("\nFinal Matching:");
-        finalMatching.getAllMatches().forEach((proposer, proposee) -> 
-            System.out.println("  " + proposer.getName() + " ↔ " + proposee.getName())
-        );
+        finalMatching.getAllMatches().forEach((proposer, proposee) -> {
+            if (proposee instanceof EmptySet) {
+                System.out.println("  " + proposer.getName() + " → single");
+            } else {
+                System.out.println("  " + proposer.getName() + " ↔ " + proposee.getName());
+            }
+        });
         
         if (!finalMatching.getUnmatchedProposers().isEmpty()) {
             System.out.println("\nUnmatched Proposers:");

--- a/src/test/java/com/galeshapley/algorithm/EmptySetPreferenceTest.java
+++ b/src/test/java/com/galeshapley/algorithm/EmptySetPreferenceTest.java
@@ -1,0 +1,74 @@
+package com.galeshapley.algorithm;
+
+import com.galeshapley.model.*;
+import org.junit.jupiter.api.Test;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EmptySetPreferenceTest {
+    
+    @Test
+    void shouldHandleEmptySetAsFirstPreference() {
+        // Create proposers and proposees
+        Proposer singlePreferrer = new Proposer("m1", "SinglePreferrer");
+        Proposer regularGuy = new Proposer("m2", "RegularGuy");
+        Proposee alice = new Proposee("w1", "Alice");
+        Proposee betty = new Proposee("w2", "Betty");
+        
+        // SinglePreferrer prefers Alice then Betty (but empty set will be inserted at position 0)
+        List<Proposee> singlePreferrerList = Arrays.asList(alice, betty);
+        PreferenceList<Proposee> singlePreferrerPrefs = new PreferenceList<>(singlePreferrer, singlePreferrerList);
+        
+        // RegularGuy prefers Alice then Betty
+        List<Proposee> regularGuyList = Arrays.asList(alice, betty);
+        PreferenceList<Proposee> regularGuyPrefs = new PreferenceList<>(regularGuy, regularGuyList);
+        
+        // Alice prefers SinglePreferrer then RegularGuy
+        List<Proposer> aliceList = Arrays.asList(singlePreferrer, regularGuy);
+        PreferenceList<Proposer> alicePrefs = new PreferenceList<>(alice, aliceList);
+        
+        // Betty prefers RegularGuy then SinglePreferrer  
+        List<Proposer> bettyList = Arrays.asList(regularGuy, singlePreferrer);
+        PreferenceList<Proposer> bettyPrefs = new PreferenceList<>(betty, bettyList);
+        
+        Map<Proposer, PreferenceList<Proposee>> proposerPreferences = new HashMap<>();
+        proposerPreferences.put(singlePreferrer, singlePreferrerPrefs);
+        proposerPreferences.put(regularGuy, regularGuyPrefs);
+        
+        Map<Proposee, PreferenceList<Proposer>> proposeePreferences = new HashMap<>();
+        proposeePreferences.put(alice, alicePrefs);
+        proposeePreferences.put(betty, bettyPrefs);
+        
+        // Set empty set preference for SinglePreferrer at position 0 (prefers being single)
+        Map<Proposer, Integer> emptySetPreferences = new HashMap<>();
+        emptySetPreferences.put(singlePreferrer, 0);
+        
+        // Run algorithm
+        GaleShapleyAlgorithm algorithm = new GaleShapleyAlgorithm(
+            proposerPreferences, proposeePreferences, emptySetPreferences);
+        
+        GaleShapleyAlgorithm.AlgorithmResult result = algorithm.execute();
+        
+        // SinglePreferrer should be matched to EmptySet (choosing to be single)
+        assertThat(result.getFinalMatching().isMatched(singlePreferrer))
+            .as("SinglePreferrer should be matched (to EmptySet)")
+            .isTrue();
+        assertThat(result.getFinalMatching().getMatch(singlePreferrer))
+            .as("SinglePreferrer should be matched to EmptySet")
+            .hasValue(EmptySet.getInstance());
+            
+        // RegularGuy should be matched to Alice (his first preference)
+        assertThat(result.getFinalMatching().isMatched(regularGuy))
+            .as("RegularGuy should be matched")
+            .isTrue();
+        assertThat(result.getFinalMatching().getMatch(regularGuy))
+            .as("RegularGuy should be matched to Alice")
+            .hasValue(alice);
+            
+        // Betty should be unmatched
+        assertThat(result.getFinalMatching().isMatched(betty))
+            .as("Betty should be unmatched")
+            .isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Refactored algorithm to model "being single" as matching with an EmptySet entity
- Fixed bug where proposers with empty set as first preference were still proposing to others
- Improved output formatting to show "single" instead of EmptySet technical details

## Changes
1. **Created EmptySet entity**: A special Proposee that represents choosing to be single
2. **Algorithm refactoring**: Empty set is now treated as a matchable entity that always accepts proposals
3. **Output improvements**: Console displays user-friendly "single" instead of "matched with EmptySet"

## Test Plan
- [x] Created new unit test `EmptySetPreferenceTest` to verify empty set matching
- [x] Updated integration test to verify correct empty set behavior
- [x] All existing tests pass
- [x] Manual testing with empty-set-config.yaml shows correct "single" output

## Example Output
Before: `SinglePreferrer ↔ EmptySet`
After: `SinglePreferrer → single`

🤖 Generated with [Claude Code](https://claude.ai/code)