### PR TITLE
Add proposee empty set preference support

### DIFF
--- a/src/main/java/com/galeshapley/config/SimulationConfig.java
+++ b/src/main/java/com/galeshapley/config/SimulationConfig.java
@@ -9,6 +9,7 @@ public class SimulationConfig {
     private final Map<Proposer, PreferenceList<Proposee>> proposerPreferences;
     private final Map<Proposee, PreferenceList<Proposer>> proposeePreferences;
     private final Map<Proposer, Integer> emptySetPreferences;
+    private final Map<Proposee, Integer> proposeeEmptySetPreferences;
     
     private SimulationConfig(Builder builder) {
         this.proposers = Collections.unmodifiableSet(new HashSet<>(builder.proposers));
@@ -16,6 +17,7 @@ public class SimulationConfig {
         this.proposerPreferences = Collections.unmodifiableMap(new HashMap<>(builder.proposerPreferences));
         this.proposeePreferences = Collections.unmodifiableMap(new HashMap<>(builder.proposeePreferences));
         this.emptySetPreferences = Collections.unmodifiableMap(new HashMap<>(builder.emptySetPreferences));
+        this.proposeeEmptySetPreferences = Collections.unmodifiableMap(new HashMap<>(builder.proposeeEmptySetPreferences));
         validate();
     }
     
@@ -44,7 +46,8 @@ public class SimulationConfig {
                 throw new IllegalStateException("Proposee " + proposee.getName() + " has no preferences");
             }
             PreferenceList<Proposer> prefs = proposeePreferences.get(proposee);
-            if (!prefs.getPreferences().containsAll(proposers)) {
+            // Skip validation for proposees with empty set preferences (they don't need all proposers)
+            if (!proposeeEmptySetPreferences.containsKey(proposee) && !prefs.getPreferences().containsAll(proposers)) {
                 throw new IllegalStateException("Proposee " + proposee.getName() + 
                     " does not have preferences for all proposers");
             }
@@ -71,6 +74,10 @@ public class SimulationConfig {
         return emptySetPreferences;
     }
     
+    public Map<Proposee, Integer> getProposeeEmptySetPreferences() {
+        return proposeeEmptySetPreferences;
+    }
+    
     public static Builder builder() {
         return new Builder();
     }
@@ -81,6 +88,7 @@ public class SimulationConfig {
         private final Map<Proposer, PreferenceList<Proposee>> proposerPreferences = new HashMap<>();
         private final Map<Proposee, PreferenceList<Proposer>> proposeePreferences = new HashMap<>();
         private final Map<Proposer, Integer> emptySetPreferences = new HashMap<>();
+        private final Map<Proposee, Integer> proposeeEmptySetPreferences = new HashMap<>();
         
         public Builder addProposer(Proposer proposer) {
             proposers.add(proposer);
@@ -123,6 +131,14 @@ public class SimulationConfig {
                 throw new IllegalArgumentException("Proposer " + proposer + " not in configuration");
             }
             emptySetPreferences.put(proposer, position);
+            return this;
+        }
+        
+        public Builder setProposeeEmptySetPreference(Proposee proposee, int position) {
+            if (!proposees.contains(proposee)) {
+                throw new IllegalArgumentException("Proposee " + proposee + " not in configuration");
+            }
+            proposeeEmptySetPreferences.put(proposee, position);
             return this;
         }
         

--- a/src/main/java/com/galeshapley/config/SimulationConfigLoader.java
+++ b/src/main/java/com/galeshapley/config/SimulationConfigLoader.java
@@ -98,7 +98,11 @@ public class SimulationConfigLoader {
                 throw new IllegalArgumentException("Unknown proposee ID in preferences: " + entry.getKey());
             }
             
+            // Find position of empty set (if any) in original preference list
+            int emptySetPosition = entry.getValue().indexOf("∅");
+            
             List<Proposer> preferenceList = entry.getValue().stream()
+                .filter(id -> !id.equals("∅"))  // Filter out empty set symbol
                 .map(id -> {
                     Proposer proposer = proposerMap.get(id);
                     if (proposer == null) {
@@ -109,6 +113,11 @@ public class SimulationConfigLoader {
                 .collect(Collectors.toList());
             
             builder.setProposeePreferences(proposee, preferenceList);
+            
+            // If empty set was found, set the proposee empty set preference
+            if (emptySetPosition != -1) {
+                builder.setProposeeEmptySetPreference(proposee, emptySetPosition);
+            }
         }
         
         return builder.build();

--- a/src/main/java/com/galeshapley/model/Agent.java
+++ b/src/main/java/com/galeshapley/model/Agent.java
@@ -5,10 +5,16 @@ import java.util.Objects;
 public abstract class Agent {
     private final String id;
     private final String name;
+    protected final boolean isEmptySet;
 
     protected Agent(String id, String name) {
+        this(id, name, false);
+    }
+    
+    protected Agent(String id, String name, boolean isEmptySet) {
         this.id = Objects.requireNonNull(id, "Agent ID cannot be null");
         this.name = Objects.requireNonNull(name, "Agent name cannot be null");
+        this.isEmptySet = isEmptySet;
     }
 
     public String getId() {
@@ -17,6 +23,10 @@ public abstract class Agent {
 
     public String getName() {
         return name;
+    }
+    
+    public boolean isEmptySet() {
+        return isEmptySet;
     }
 
     @Override

--- a/src/main/java/com/galeshapley/model/EmptySet.java
+++ b/src/main/java/com/galeshapley/model/EmptySet.java
@@ -8,7 +8,7 @@ public class EmptySet extends Proposee {
     private static final EmptySet INSTANCE = new EmptySet();
     
     private EmptySet() {
-        super("∅", "EmptySet");
+        super("∅", "EmptySet", true);
     }
     
     public static EmptySet getInstance() {

--- a/src/main/java/com/galeshapley/model/Proposee.java
+++ b/src/main/java/com/galeshapley/model/Proposee.java
@@ -6,6 +6,10 @@ public class Proposee extends Agent {
         super(id, name);
     }
     
+    protected Proposee(String id, String name, boolean isEmptySet) {
+        super(id, name, isEmptySet);
+    }
+    
     public static Proposee create(String id, String name) {
         return new Proposee(id, name);
     }

--- a/src/test/java/com/galeshapley/integration/EndToEndIntegrationTest.java
+++ b/src/test/java/com/galeshapley/integration/EndToEndIntegrationTest.java
@@ -153,7 +153,8 @@ class EndToEndIntegrationTest {
         GaleShapleyAlgorithm algorithm = new GaleShapleyAlgorithm(
             config.getProposerPreferences(),
             config.getProposeePreferences(),
-            config.getEmptySetPreferences()
+            config.getEmptySetPreferences(),
+            config.getProposeeEmptySetPreferences()
         );
         
         StatisticsObserver statisticsObserver = new StatisticsObserver();
@@ -171,8 +172,10 @@ class EndToEndIntegrationTest {
             .filter(p -> p.getName().equals("SinglePreferrer"))
             .findFirst().orElseThrow();
         assertThat(allMatches.get(singlePreferrer))
-            .isInstanceOf(com.galeshapley.model.EmptySet.class)
-            .satisfies(match -> assertThat(match.getName()).isEqualTo("EmptySet"));
+            .satisfies(match -> {
+                assertThat(match.isEmptySet()).isTrue();
+                assertThat(match.getName()).isEqualTo("EmptySet");
+            });
         
         // And: The algorithm should still achieve the best possible matching for others
         assertThat(result.getFinalMatching().getMatchCount()).isEqualTo(2); // SinglePreferrer-EmptySet, RegularGuy-Alice
@@ -190,5 +193,50 @@ class EndToEndIntegrationTest {
                 Proposee unmatchedProposee = unmatched.iterator().next();
                 assertThat(unmatchedProposee.getName()).isEqualTo("Betty");
             });
+    }
+    
+    @Test
+    void shouldHandleEmptySetAsFirstPreferenceForProposee() throws IOException {
+        // Given: A YAML configuration where a proposee has empty set as first preference
+        SimulationConfigLoader loader = new SimulationConfigLoader();
+        SimulationConfig config = loader.loadFromFile("src/test/resources/proposee-empty-set-first-config.yaml");
+        
+        GaleShapleyAlgorithm algorithm = new GaleShapleyAlgorithm(
+            config.getProposerPreferences(),
+            config.getProposeePreferences(),
+            config.getEmptySetPreferences(),
+            config.getProposeeEmptySetPreferences()
+        );
+        
+        StatisticsObserver statisticsObserver = new StatisticsObserver();
+        algorithm.addObserver(statisticsObserver);
+        
+        GaleShapleyAlgorithm.AlgorithmResult result = algorithm.execute();
+        
+        // Then: SingleLady should choose to remain single (matched to EmptySet)
+        // and the proposers should get matched optimally among themselves
+        var allMatches = result.getFinalMatching().getAllMatches();
+        
+        // Verify SingleLady is NOT matched to any proposer (chose to be single)
+        boolean singleLadyIsMatched = allMatches.values().stream()
+            .anyMatch(proposee -> proposee.getName().equals("SingleLady"));
+        assertThat(singleLadyIsMatched).isFalse();
+        
+        // Verify SingleLady is in unmatched proposees (since she chose to be single)
+        assertThat(result.getFinalMatching().getUnmatchedProposees())
+            .hasSize(1)
+            .satisfies(unmatched -> {
+                Proposee unmatchedProposee = unmatched.iterator().next();
+                assertThat(unmatchedProposee.getName()).isEqualTo("SingleLady");
+            });
+        
+        // Verify the remaining proposer and proposee are matched
+        assertThat(result.getFinalMatching().getMatchCount()).isEqualTo(1);
+        assertThat(result.getFinalMatching().getUnmatchedProposers()).hasSize(1);
+        
+        // Verify no "proposal" to empty set is counted in statistics
+        StatisticsObserver.Statistics stats = statisticsObserver.getStatistics();
+        // The algorithm should not count choosing to be single as a real proposal
+        assertThat(stats.getTotalProposals()).isLessThanOrEqualTo(2); // Maximum 2 real proposals
     }
 }

--- a/src/test/resources/proposee-empty-set-first-config.yaml
+++ b/src/test/resources/proposee-empty-set-first-config.yaml
@@ -1,0 +1,17 @@
+simulation:
+  proposers:
+    - id: m1
+      name: RegularGuy
+    - id: m2
+      name: AnotherGuy
+  proposees:
+    - id: w1
+      name: SingleLady
+    - id: w2
+      name: NormalWoman
+  proposerPreferences:
+    m1: [w1, w2]     # RegularGuy prefers SingleLady > NormalWoman
+    m2: [w2, w1]     # AnotherGuy prefers NormalWoman > SingleLady
+  proposeePreferences:
+    w1: ["∅", m1, m2]  # SingleLady prefers empty set (being single) > RegularGuy > AnotherGuy
+    w2: [m1, m2]       # NormalWoman prefers RegularGuy > AnotherGuy


### PR DESCRIPTION
## Summary

This PR enhances the Gale-Shapley algorithm to support proposees who prefer to remain single over certain proposers. This addresses a gap in the current implementation where only proposers could have empty set preferences.

## Key Changes

- **Enhanced Configuration**: Added `proposeeEmptySetPreferences` support to `SimulationConfig` and `SimulationConfigLoader`
- **Algorithm Improvements**: Updated `GaleShapleyAlgorithm` to handle proposee rejection based on empty set preferences  
- **Cleaner Architecture**: Replaced `instanceof EmptySet` checks with `isEmptySet()` method on `Agent` class
- **Accurate Statistics**: Fixed proposal counting to exclude immediately rejected proposals due to empty set preferences
- **Comprehensive Testing**: Added test case for proposee with empty set as first preference

## Behavior Changes

✅ **Proposees can now prefer remaining single** over less preferred proposers  
✅ **Accurate proposal statistics** - doesn't count "choosing to be single" as real proposals  
✅ **Clean output** - EmptySet doesn't appear as a real agent in final matching  
✅ **Implicit empty set** - All proposees have empty set at bottom of preferences if not explicitly specified

## Test Plan

- [x] New test: `shouldHandleEmptySetAsFirstPreferenceForProposee()` 
- [x] All existing tests pass (27/27)
- [x] Integration tests verify backward compatibility
- [x] Algorithm correctly handles mixed scenarios (proposers and proposees with empty set preferences)

This enhancement makes the algorithm more realistic by allowing both sides of the market to have preferences for remaining unmatched.

🤖 Generated with [Claude Code](https://claude.ai/code)