### PR TITLE
Fix Spring bean conflict in RuntimeOptions

### DIFF
--- a/src/main/java/com/galeshapley/config/RuntimeOptions.java
+++ b/src/main/java/com/galeshapley/config/RuntimeOptions.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
  * - Environment variables: GALESHAPLEY_MAXITERATIONS, GALESHAPLEY_ENABLEDETAILEDLOGGING, etc.
  * - Command line arguments: --galeshapley.maxIterations=1000, --galeshapley.enableDetailedLogging=true
  */
-@Component
 @ConfigurationProperties(prefix = "galeshapley")
 public class RuntimeOptions {
     private int maxIterations = Integer.MAX_VALUE;


### PR DESCRIPTION
## Summary
• Fix NoUniqueBeanDefinitionException by removing duplicate @Component annotation
• Resolve Spring bean conflict between @Component and @EnableConfigurationProperties
• Ensures simulation commands work properly with environment variables

## Test plan
- [x] Verify GALESHAPLEY_MAXITERATIONS=10 ./run-simulation works without bean conflict error
- [x] Confirm Spring Boot properly loads RuntimeOptions configuration
- [x] Test environment variable override functionality

🤖 Generated with [Claude Code](https://claude.ai/code)