### PR TITLE
Fix bean conflict, proposee count bugs and improve statistics output clarity

### DIFF
--- a/src/main/java/com/galeshapley/algorithm/GaleShapleyAlgorithm.java
+++ b/src/main/java/com/galeshapley/algorithm/GaleShapleyAlgorithm.java
@@ -262,9 +262,14 @@ public class GaleShapleyAlgorithm {
     }
 
     private void notifyStart() {
+        // Filter out EmptySet instances when counting proposees
+        Set<Proposee> realProposees = proposeePreferences.keySet().stream()
+            .filter(p -> !(p instanceof EmptySet))
+            .collect(java.util.stream.Collectors.toSet());
+            
         observers.forEach(observer -> observer.onAlgorithmStart(
             new HashSet<>(proposerPreferences.keySet()),
-            new HashSet<>(proposeePreferences.keySet())
+            realProposees
         ));
     }
 

--- a/src/main/java/com/galeshapley/config/RuntimeOptions.java
+++ b/src/main/java/com/galeshapley/config/RuntimeOptions.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
  * - Environment variables: GALESHAPLEY_MAXITERATIONS, GALESHAPLEY_ENABLEDETAILEDLOGGING, etc.
  * - Command line arguments: --galeshapley.maxIterations=1000, --galeshapley.enableDetailedLogging=true
  */
-@Component
 @ConfigurationProperties(prefix = "galeshapley")
 public class RuntimeOptions {
     private int maxIterations = Integer.MAX_VALUE;

--- a/src/main/java/com/galeshapley/observer/StatisticsObserver.java
+++ b/src/main/java/com/galeshapley/observer/StatisticsObserver.java
@@ -8,11 +8,13 @@ public class StatisticsObserver implements AlgorithmObserver {
     private int totalProposals = 0;
     private int totalAcceptances = 0;
     private int totalRejections = 0;
+    private int totalBrokenEngagements = 0; // When someone gets displaced by a better proposal
     private int totalIterationAttempts = 0; // Tracks all proposal attempts including those to empty sets
     private Map<Proposer, Integer> proposalCountByProposer = new HashMap<>();
     private Map<Proposer, Integer> rejectionCountByProposer = new HashMap<>();
     private Map<Proposer, Integer> iterationAttemptsByProposer = new HashMap<>();
     private Map<Proposee, Integer> proposalReceivedCount = new HashMap<>();
+    private Set<Proposer> previouslyMatchedProposers = new HashSet<>(); // Track who was previously matched
     private long startTime;
     private long endTime;
     
@@ -42,12 +44,18 @@ public class StatisticsObserver implements AlgorithmObserver {
     @Override
     public void onAcceptance(Proposer proposer, Proposee proposee) {
         totalAcceptances++;
+        previouslyMatchedProposers.add(proposer); // Track that this proposer has been matched
     }
     
     @Override
     public void onRejection(Proposer proposer, Proposee proposee) {
         totalRejections++;
         rejectionCountByProposer.merge(proposer, 1, Integer::sum);
+        
+        // If this proposer was previously matched, this is a broken engagement
+        if (previouslyMatchedProposers.contains(proposer)) {
+            totalBrokenEngagements++;
+        }
     }
     
     @Override
@@ -73,6 +81,7 @@ public class StatisticsObserver implements AlgorithmObserver {
         private final int totalProposals;
         private final int totalAcceptances;
         private final int totalRejections;
+        private final int totalBrokenEngagements;
         private final int totalIterationAttempts;
         private final Map<Proposer, Integer> proposalCountByProposer;
         private final Map<Proposer, Integer> rejectionCountByProposer;
@@ -84,6 +93,7 @@ public class StatisticsObserver implements AlgorithmObserver {
             this.totalProposals = observer.totalProposals;
             this.totalAcceptances = observer.totalAcceptances;
             this.totalRejections = observer.totalRejections;
+            this.totalBrokenEngagements = observer.totalBrokenEngagements;
             this.totalIterationAttempts = observer.totalIterationAttempts;
             this.proposalCountByProposer = new HashMap<>(observer.proposalCountByProposer);
             this.rejectionCountByProposer = new HashMap<>(observer.rejectionCountByProposer);
@@ -102,6 +112,10 @@ public class StatisticsObserver implements AlgorithmObserver {
         
         public int getTotalRejections() {
             return totalRejections;
+        }
+        
+        public int getTotalBrokenEngagements() {
+            return totalBrokenEngagements;
         }
         
         public int getTotalIterationAttempts() {
@@ -147,19 +161,28 @@ public class StatisticsObserver implements AlgorithmObserver {
         @Override
         public String toString() {
             return String.format(
-                "Statistics{\n" +
-                "  Total Iteration Attempts: %d\n" +
-                "  Total Proposals: %d\n" +
-                "  Total Acceptances: %d\n" +
-                "  Total Rejections: %d\n" +
-                "  Avg Iteration Attempts/Proposer: %.2f\n" +
-                "  Avg Proposals/Proposer: %.2f\n" +
-                "  Avg Rejections/Proposer: %.2f\n" +
-                "  Avg Proposals Received/Proposee: %.2f\n" +
-                "  Execution Time: %d ms\n" +
-                "}",
-                totalIterationAttempts, totalProposals, totalAcceptances, totalRejections,
-                getAverageIterationAttemptsPerProposer(),
+                "Algorithm Execution Statistics:\n" +
+                "══════════════════════════════════════════════════════════════════\n" +
+                "\n" +
+                "📊 PROPOSAL ACTIVITY:\n" +
+                "  • Meaningful Proposals Made: %d (actual romantic proposals)\n" +
+                "  • Proposals Accepted: %d (successful matches formed)\n" +
+                "  • Total Rejections: %d (all declined offers)\n" +
+                "    ├─ Broken Engagements: %d (displaced by better offer)\n" +
+                "    └─ Direct Rejections: %d (immediate 'no' without engagement)\n" +
+                "\n" +
+                "🔄 ALGORITHM MECHANICS:\n" +
+                "  • Total Decision Points: %d (includes evaluating 'stay single')\n" +
+                "\n" +
+                "📈 COMPETITION METRICS:\n" +
+                "  • Avg Proposals per Proposer: %.2f (how hard they had to try)\n" +
+                "  • Avg Rejections per Proposer: %.2f (how much competition faced)\n" +
+                "  • Avg Proposals per Proposee: %.2f (how popular/in-demand)\n" +
+                "\n" +
+                "⏱️  PERFORMANCE:\n" +
+                "  • Execution Time: %d ms\n",
+                totalProposals, totalAcceptances, totalRejections, totalBrokenEngagements, (totalRejections - totalBrokenEngagements),
+                totalIterationAttempts,
                 getAverageProposalsPerProposer(),
                 getAverageRejectionsPerProposer(),
                 getAverageProposalsReceivedPerProposee(),

--- a/src/test/java/com/galeshapley/integration/CommandOutputIntegrationTest.java
+++ b/src/test/java/com/galeshapley/integration/CommandOutputIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.galeshapley.integration;
+
+import com.galeshapley.algorithm.GaleShapleyAlgorithm;
+import com.galeshapley.config.RuntimeOptions;
+import com.galeshapley.config.SimulationConfig;
+import com.galeshapley.config.SimulationConfigLoader;
+import com.galeshapley.observer.ConsoleObserver;
+import com.galeshapley.observer.StatisticsObserver;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CommandOutputIntegrationTest {
+    
+    @Test
+    void shouldProduceExpectedOutputForAsymmetricMatchingConfig() throws IOException {
+        // Given: Capture console output
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outputStream));
+        
+        try {
+            // Load the asymmetric matching configuration
+            SimulationConfigLoader loader = new SimulationConfigLoader();
+            SimulationConfig config = loader.loadFromFile("src/test/resources/asymmetric-matching-config.yaml");
+            
+            RuntimeOptions runtimeOptions = RuntimeOptions.builder()
+                .maxIterations(10)
+                .enableDetailedLogging(false)
+                .trackIterationMetrics(true)
+                .build();
+            
+            GaleShapleyAlgorithm algorithm = new GaleShapleyAlgorithm(
+                config.getProposerPreferences(),
+                config.getProposeePreferences(),
+                config.getEmptySetPreferences()
+            );
+            
+            ConsoleObserver consoleObserver = new ConsoleObserver(runtimeOptions.isDetailedLoggingEnabled());
+            StatisticsObserver statisticsObserver = new StatisticsObserver();
+            
+            algorithm.addObserver(consoleObserver);
+            algorithm.addObserver(statisticsObserver);
+            
+            // When: Execute the algorithm
+            GaleShapleyAlgorithm.AlgorithmResult result = algorithm.execute(runtimeOptions);
+            
+            // Print statistics
+            if (runtimeOptions.isTrackIterationMetrics()) {
+                System.out.println("\n=== Statistics ===");
+                System.out.println(statisticsObserver.getStatistics());
+            }
+            
+        } finally {
+            System.setOut(originalOut);
+        }
+        
+        String output = outputStream.toString();
+        
+        // Then: Verify expected output structure and content
+        assertThat(output)
+            .contains("=== Gale-Shapley Algorithm Started ===")
+            .contains("Proposers: 4")
+            .contains("Proposees: 2")  // Should show correct count (not 3)
+            .contains("Anna accepts")
+            .contains("Beth accepts")
+            .contains("=== Algorithm Complete ===")
+            .contains("Total iterations: 1")
+            .contains("Final Matching:")
+            .contains("Ben ↔ Anna")
+            .contains("Carl ↔ Beth")
+            .contains("Unmatched Proposers:")
+            .contains("- Adam")
+            .contains("- Dave")
+            .contains("=== Statistics ===");
+        
+        // Verify new improved statistics section contains expected metrics
+        assertThat(output)
+            .contains("Algorithm Execution Statistics:")
+            .contains("📊 PROPOSAL ACTIVITY:")
+            .contains("Meaningful Proposals Made:")
+            .contains("Proposals Accepted:")
+            .contains("Total Rejections:")
+            .contains("Broken Engagements:")
+            .contains("Direct Rejections:")
+            .contains("🔄 ALGORITHM MECHANICS:")
+            .contains("Total Decision Points:")
+            .contains("📈 COMPETITION METRICS:")
+            .contains("Avg Proposals per Proposer:")
+            .contains("Avg Rejections per Proposer:")
+            .contains("Avg Proposals per Proposee:")
+            .contains("⏱️  PERFORMANCE:")
+            .contains("Execution Time:");
+        
+        // Verify no unmatched proposees (all 2 proposees should be matched)
+        assertThat(output).doesNotContain("Unmatched Proposees:");
+        
+        // Verify specific expected values  
+        assertThat(output).contains("Avg Proposals per Proposee: 2.00");
+    }
+}


### PR DESCRIPTION
## Summary
• **Fix Spring bean conflict** - Remove duplicate @Component annotation from RuntimeOptions to resolve NoUniqueBeanDefinitionException
• **Fix proposee count bug** - Correct display showing "Proposees: 3" instead of "Proposees: 2" by filtering EmptySet from count
• **Add broken engagement tracking** - Distinguish between direct rejections vs being displaced by better offers  
• **Dramatically improve statistics output** with clear explanations, emoji sections, and intuitive language
• **Add comprehensive integration test** to validate command output format and prevent regressions

## Key Improvements

### Before:
```
Statistics{
  Total Iteration Attempts: 4
  Total Proposals: 4  
  Total Acceptances: 3
  Total Rejections: 2
  Avg Proposals/Proposer: 1.00
  ...
}
```

### After:
```
Algorithm Execution Statistics:
══════════════════════════════════════════════════════════════════

📊 PROPOSAL ACTIVITY:
  • Meaningful Proposals Made: 4 (actual romantic proposals)
  • Proposals Accepted: 3 (successful matches formed)
  • Total Rejections: 2 (all declined offers)
    ├─ Broken Engagements: 1 (displaced by better offer)
    └─ Direct Rejections: 1 (immediate 'no' without engagement)

🔄 ALGORITHM MECHANICS:
  • Total Decision Points: 4 (includes evaluating 'stay single')

📈 COMPETITION METRICS:
  • Avg Proposals per Proposer: 1.00 (how hard they had to try)
  • Avg Rejections per Proposer: 0.50 (how much competition faced)
  • Avg Proposals per Proposee: 2.00 (how popular/in-demand)

⏱️  PERFORMANCE:
  • Execution Time: 2 ms
```

## Test Plan
- [x] All 36 tests pass including new integration test  
- [x] Verify `GALESHAPLEY_MAXITERATIONS=10 ./run-simulation` works without bean conflict
- [x] Confirm proposee count shows correct value (2 not 3)
- [x] Validate broken engagement tracking works correctly
- [x] Check statistics output is clear and informative

## Bug Fixes Verified
1. **Bean Conflict**: `GALESHAPLEY_MAXITERATIONS=10 ./run-simulation` now works without NoUniqueBeanDefinitionException
2. **Proposee Count**: Output correctly shows "Proposees: 2" instead of "Proposees: 3"  
3. **Broken Engagements**: Now tracks when Adam gets displaced by Ben's better proposal to Anna

🤖 Generated with [Claude Code](https://claude.ai/code)